### PR TITLE
Add ai-i18n action

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Add Reviewers](https://github.com/marketplace/actions/add-reviewers): Github action that adds Reviewers to the Pull Request.
 
+[ai-i18n](https://github.com/i18n-actions/ai-i18n): GitHub Action to automatically translate i18n files (XLIFF, JSON) using LLM providers (Anthropic, OpenAI, Ollama) with glossary support, change detection, and reviewed translation preservation.
+
 [![App Token](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/app-token.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/app-token.yml)
 
 [App Token](https://github.com/marketplace/actions/github-app-token): Github Action to impersonate a GitHub App when `secrets.GITHUB_TOKEN`'s limitations are too restrictive and a personal access token is not suitable.


### PR DESCRIPTION
This PR adds [ai-i18n](https://github.com/i18n-actions/ai-i18n) to the Global Actions section. ai-i18n is a GitHub Action that automatically translates i18n files (XLIFF, JSON) using LLM providers (Anthropic, OpenAI, Ollama) with glossary support, change detection, and reviewed translation preservation.