### PR TITLE
feat: add NHS Score Check action

### DIFF
--- a/.github/workflows/nhs-score-check.yml
+++ b/.github/workflows/nhs-score-check.yml
@@ -1,0 +1,16 @@
+name: NHS Score Check
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  nhs-score-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check agentic readiness score
+        uses: unitedideas/nhs-score-check-action@v1
+        with:
+          domain: example.com
+          min-score: '0'

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Manual Approval](https://github.com/marketplace/actions/manual-workflow-approval): Github Action to pause a workflow and require manual approval from **one or more** approvers before continuing.
 
+[![NHS Score Check](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/nhs-score-check.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/nhs-score-check.yml)
+
+[NHS Score Check](https://github.com/marketplace/actions/nhs-agentic-readiness-check): GitHub Action to fetch a site's agentic readiness score from [Not Human Search](https://nothumansearch.ai) and fail the build if it drops below a minimum threshold. Similar in spirit to Lighthouse CI, but for AI-agent signals (`llms.txt`, `ai-plugin.json`, OpenAPI, MCP server, schema.org, AI-aware `robots.txt`). Useful as a CI guardrail so a regression in agent-readable metadata gets caught before merge.
+
 [![Paths Filter](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/paths-filter.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/paths-filter.yml)
 
 [Paths Filter](https://github.com/marketplace/actions/paths-changes-filter): Github Action that enables conditional execution of workflow steps and jobs, based on the files modified by pull request, on a feature branch, or by the recently pushed commits.


### PR DESCRIPTION
## What

Adds [NHS Agentic Readiness Check](https://github.com/unitedideas/nhs-score-check-action) to the **Global Actions** section (alphabetically between _Manual Approval_ and _Paths Filter_).

## Why it's useful

GitHub workflows already cover a lot of code-quality signals (tests, linters, Lighthouse CI, security scans), but there is no standard way to guard **agent-readable** signals on a regression. This action fetches a domain's agentic readiness score from [Not Human Search](https://nothumansearch.ai) and fails the build if it drops below a configurable threshold.

It checks whether the site exposes, and keeps exposing:

- `llms.txt` / `llms-full.txt`
- `ai-plugin.json`
- OpenAPI spec
- MCP server endpoint
- `schema.org` JSON-LD
- AI-aware `robots.txt`
- structured API endpoints

Useful as a CI guardrail so an accidental deploy that breaks one of these (a missing file, a broken JSON-LD, a stray `Disallow: /` for GPTBot) gets caught before merge, not weeks later when agentic traffic drops.

## Changes

- `README.md` — single new entry in the Global Actions list, alphabetical order preserved.
- `.github/workflows/nhs-score-check.yml` — minimal workflow example following the repo pattern (push + workflow_dispatch), uses `example.com` with `min-score: '0'` so the example workflow never fails the build here.

## Action details

- Source: https://github.com/unitedideas/nhs-score-check-action (MIT)
- Type: composite action (bash + `jq`)
- Inputs: `domain` (required), `min-score` (default 50), `recrawl` (default false)
- Outputs: `score`, `signals` (JSON map), `report-url`

## Checklist

- [x] Contents in English
- [x] Added to Global Actions section, alphabetical order respected
- [x] New workflow file under `.github/workflows/` per CONTRIBUTING.md
- [x] Workflow triggers include `workflow_dispatch`
- [x] Branch named `feature/<action-name>` per CONTRIBUTING.md

Happy to iterate if you'd prefer a different section or a different example domain.