### PR TITLE
Add FailureMemory to the useful actions list

### DIFF
--- a/.github/workflows/failurememory.yml
+++ b/.github/workflows/failurememory.yml
@@ -1,30 +1,42 @@
 name: FailureMemory
 
 on:
-  push:
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 jobs:
-  fingerprint-exported-log:
+  fingerprint-failure:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Create a demo log file
-        run: |
-          mkdir -p logs
-          cat <<'EOF' > logs/latest-failure.log
-          2026-04-20T05:11:01.1000000Z AssertionError: expected undefined to be defined
-          2026-04-20T05:11:01.2000000Z ##[error]AssertionError: expected undefined to be defined
-          2026-04-20T05:11:01.3000000Z error Command failed with exit code 1.
-          EOF
+      - name: Restore prior FailureMemory history
+        uses: actions/cache/restore@v4
+        with:
+          path: .failurememory
+          key: failurememory-${{ github.repository }}-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.id }}
+          restore-keys: |
+            failurememory-${{ github.repository }}-${{ github.event.workflow_run.head_branch }}-
 
-      - name: Fingerprint exported log file
+      - name: Fingerprint the failing run
         id: failurememory
         uses: UnguisAI/failurememory@v0
         with:
-          fetch_mode: file
-          log_path: logs/latest-failure.log
+          fetch_mode: github
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Save updated FailureMemory history
+        if: ${{ always() }}
+        uses: actions/cache/save@v4
+        with:
+          path: .failurememory
+          key: failurememory-${{ github.repository }}-${{ github.event.workflow_run.head_branch }}-${{ github.run_id }}
 
       - name: Print summary
         run: |

--- a/.github/workflows/failurememory.yml
+++ b/.github/workflows/failurememory.yml
@@ -1,0 +1,33 @@
+name: FailureMemory
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  fingerprint-exported-log:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create a demo log file
+        run: |
+          mkdir -p logs
+          cat <<'EOF' > logs/latest-failure.log
+          2026-04-20T05:11:01.1000000Z AssertionError: expected undefined to be defined
+          2026-04-20T05:11:01.2000000Z ##[error]AssertionError: expected undefined to be defined
+          2026-04-20T05:11:01.3000000Z error Command failed with exit code 1.
+          EOF
+
+      - name: Fingerprint exported log file
+        id: failurememory
+        uses: UnguisAI/failurememory@v0
+        with:
+          fetch_mode: file
+          log_path: logs/latest-failure.log
+
+      - name: Print summary
+        run: |
+          echo "fingerprint=${{ steps.failurememory.outputs.fingerprint }}"
+          echo "seen_count=${{ steps.failurememory.outputs.seen_count }}"
+          cat "${{ steps.failurememory.outputs.summary_path }}"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Env Vars](https://github.com/marketplace/actions/github-environment-variables-action): GitHub Action to expose useful environment variables.
 
+[![FailureMemory](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/failurememory.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/failurememory.yml)
+
+[FailureMemory](https://github.com/marketplace/actions/failurememory): GitHub Action for recurring CI failure fingerprinting and memory-backed triage so maintainers can turn repeated GitHub Actions failures into short recurrence briefs instead of re-reading the same CI noise from scratch.
+
 [![File Existence](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/file-existence.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/file-existence.yml)
 
 [File Existence](https://github.com/marketplace/actions/file-existence): Github Action to check if files exists or not.


### PR DESCRIPTION
## Summary

- add FailureMemory to the Global Actions section in README
- keep the list alphabetical
- switch the contributed workflow example to FailureMemory's failure-only GitHub-mode setup

## Why

FailureMemory is a GitHub Action for recurring CI failure fingerprinting and memory-backed triage. It helps maintainers recognize repeated GitHub Actions failures and produce a short recurrence brief instead of re-reading the same CI noise from scratch.

The workflow example now shows the intended `workflow_run` setup so the action only spends runs on failed workflows instead of generating reports on successful CI.

## Notes

- README entry links to the Marketplace listing
- example now follows the failure-only GitHub-mode quick start (`workflow_run` + cache-backed local history)
- file mode remains available for repos that already export plain-text logs, but it is no longer the contributed example here
