### PR TITLE
Add DOS Verify Gate (claim-vs-diff commit audit)

### DIFF
--- a/.github/workflows/dos-verify-gate.yml
+++ b/.github/workflows/dos-verify-gate.yml
@@ -1,0 +1,21 @@
+name: DOS Verify Gate
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dos-commit-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # commit-audit reads git ancestry
+
+      # Audits the tip commit's message against its own diff. Observe-only here
+      # (fail-on: none) so the example always passes; on a pull_request event the
+      # action defaults to auditing base..head - set fail-on: unwitnessed to make
+      # it a blocking gate.
+      - uses: anthony-chaudhary/dos-kernel/verify-action@master
+        with:
+          mode: commit-audit
+          fail-on: none

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Delete Artifacts](https://github.com/marketplace/actions/delete-artifact): GitHub Action to delete artifacts within a workflow run. This can be useful when artifacts are shared across jobs, but are no longer needed when the workflow is complete.
 
+[![DOS Verify Gate](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/dos-verify-gate.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/dos-verify-gate.yml)
+
+[DOS Verify Gate](https://github.com/anthony-chaudhary/dos-kernel/tree/master/verify-action): Github Action to fail a PR when a commit's message claims work its own diff doesn't contain (deterministic claim-vs-diff audit, abstains on commits with no checkable claim).
+
 [![Enforce PR labels](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/enforce-labels.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/enforce-labels.yml)
 
 [Enforce PR labels](https://github.com/marketplace/actions/enforce-pr-labels): GitHub Action to enforce assigning labels before merging PR's. Useful for generating automatic changelog and release notes with `github-release-notes`.


### PR DESCRIPTION
Adds **DOS Verify Gate** to Global Actions (alphabetical slot), with the required workflow example under `.github/workflows/dos-verify-gate.yml` (workflow_dispatch-triggered, observe-only so it always passes when you test it).

The action (https://github.com/anthony-chaudhary/dos-kernel/tree/master/verify-action) runs `dos commit-audit`: a deterministic claim-vs-diff gate that fails a PR when a commit's message claims work its own diff doesn't contain (a `fix:` that touched only a README, a "tests pass" that deleted assertions). It abstains on commits with no checkable claim, and the exit code is the verdict. MIT, Python (PyPI: `dos-kernel`).

Note: the entry links to the action's repo path rather than a Marketplace page — it's a subdirectory action (`uses: anthony-chaudhary/dos-kernel/verify-action@master`), which the Marketplace doesn't list but workflows consume fine, as the included example shows.