### PR TITLE
Add CI Health Audit action

### DIFF
--- a/.github/workflows/ci-health-audit.yml
+++ b/.github/workflows/ci-health-audit.yml
@@ -1,0 +1,20 @@
+name: CI Health Audit
+
+on: [workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Audit GitHub Actions workflows
+        uses: sdxiaomage/ci-health-audit@5272a910684ba066f46c3f16df2782fc7d5d0cb3 # v1.0.0
+        with:
+          path: .github/workflows
+          fail-on: none

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Checkout](https://github.com/marketplace/actions/checkout): Github Action to checks-out your repository under `$GITHUB_WORKSPACE`, so your workflow can access it.
 
+[![CI Health Audit](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/ci-health-audit.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/ci-health-audit.yml)
+
+[CI Health Audit](https://github.com/marketplace/actions/ci-health-audit): Zero-dependency static audit for common GitHub Actions security and reliability risks.
+
 [![Close Pull Request](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/close-pull-request.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/close-pull-request.yml)
 
 [Close Pull Request](https://github.com/marketplace/actions/close-pull-request): Github Action to automatically close a pull request (for example if modifying _untouchable files_).


### PR DESCRIPTION
## Summary

- add CI Health Audit to Global Actions in alphabetical order
- add a `workflow_dispatch` example with read-only permissions
- pin both actions to reviewed full commit SHAs

## Verification

- CI Health Audit self-check: 1 workflow scanned, 0 findings
- Prettier check passed for the new workflow
- `git diff --check` passed

Action: https://github.com/marketplace/actions/ci-health-audit
Repository: https://github.com/sdxiaomage/ci-health-audit