### PR TITLE
Add OutageDeck status check example

### DIFF
--- a/.github/workflows/outagedeck-status-check.yml
+++ b/.github/workflows/outagedeck-status-check.yml
@@ -1,0 +1,30 @@
+name: OutageDeck Status Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      providers:
+        description: Comma-separated cloud and SaaS provider slugs
+        required: true
+        default: github,cloudflare,vercel
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check-upstream-status:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check upstream dependencies
+        id: outagedeck
+        uses: outagedeck/status-check@v1
+        with:
+          providers: ${{ inputs.providers }}
+          fail-on: never
+
+      - name: Print reusable outputs
+        run: |
+          echo "operational=${{ steps.outagedeck.outputs.operational }}"
+          echo "alerts-url=${{ steps.outagedeck.outputs['alerts-url'] }}"

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [NHS Score Check](https://github.com/marketplace/actions/nhs-agentic-readiness-check): GitHub Action to fetch a site's agentic readiness score from [Not Human Search](https://nothumansearch.ai) and fail the build if it drops below a minimum threshold. Similar in spirit to Lighthouse CI, but for AI-agent signals (`llms.txt`, `ai-plugin.json`, OpenAPI, MCP server, schema.org, AI-aware `robots.txt`). Useful as a CI guardrail so a regression in agent-readable metadata gets caught before merge.
 
+[![OutageDeck Status Check](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/outagedeck-status-check.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/outagedeck-status-check.yml)
+
+[OutageDeck Status Check](https://github.com/outagedeck/status-check): GitHub Action to check upstream cloud and SaaS status before a workflow runs, with configurable failure thresholds and reusable results for the checked provider stack.
+
 [![Paths Filter](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/paths-filter.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/paths-filter.yml)
 
 [Paths Filter](https://github.com/marketplace/actions/paths-changes-filter): Github Action that enables conditional execution of workflow steps and jobs, based on the files modified by pull request, on a feature branch, or by the recently pushed commits.


### PR DESCRIPTION
## What changed

- add a manual OutageDeck workflow with configurable cloud and SaaS provider slugs
- keep the example warning-only while exposing the action's operational and alert-link outputs
- add the action to Global Actions in alphabetical order

## Why

The repository already shows how to check GitHub's own platform status. This example covers the wider dependency stack a workflow may need before a build or deployment, using the official status feeds reported by each provider.

I'm Kerolos, founder of OutageDeck. The action is public, keyless, read-only, and pinned through its maintained `v1` tag.

## Validation

- `actionlint` v1.7.12 passed on the new workflow
- a real run against GitHub, Cloudflare, and Vercel produced the expected provider results and prefilled stack link
- `git diff --check` passed
