### PR TITLE
Add Static Form Inspector example

### DIFF
--- a/.github/workflows/static-form-inspector.yml
+++ b/.github/workflows/static-form-inspector.yml
@@ -1,0 +1,30 @@
+name: Static Form Inspector
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "**/*.html"
+      - ".github/workflows/static-form-inspector.yml"
+  pull_request:
+    paths:
+      - "**/*.html"
+      - ".github/workflows/static-form-inspector.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  inspect-static-forms:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+
+      - name: Inspect static HTML forms
+        uses: fablgen-agent/static-form-inspector-action@v1
+        with:
+          paths: .
+          fail-on: error
+          report: static-form-inspector-report.json

--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Stale](https://github.com/marketplace/actions/close-stale-issues): GitHub Action to warn and then close issues and PRs that have had no activity for a specified amount of time.
 
+[![Static Form Inspector](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/static-form-inspector.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/static-form-inspector.yml)
+
+[Static Form Inspector](https://github.com/fablgen-agent/static-form-inspector-action): GitHub Action to inspect static HTML forms for inert or placeholder actions, contact-like GET submissions, unnamed fields, and unclosed forms without making network requests.
+
 [![Super Linter](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/super-linter.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/super-linter.yml)
 
 [Super Linter](https://github.com/marketplace/actions/super-linter): Github Action to help validate your source code.


### PR DESCRIPTION
## What changed

- adds Static Form Inspector to the alphabetical Global Actions list
- adds a runnable workflow example for manual runs and HTML changes
- uses the Action’s documented `paths`, `fail-on`, and `report` inputs
- keeps workflow permissions at `contents: read`

## Why

Static Form Inspector is a dependency-free Action for finding static HTML forms with inert or placeholder actions, contact-like GET submissions, unnamed fields, and unclosed forms. It makes no network requests, and its default behavior can report findings without breaking an existing build.

## Impact

Users get a copyable example that scans repository HTML and emits annotations, a job summary, and a JSON report. The example uses `fail-on: error`, so likely delivery failures fail the job while warnings remain visible.

## Validation

- `npx --yes yaml-lint .github/workflows/static-form-inspector.yml`
- `git diff --check`
- ran the inspector CLI against this checkout: 0 HTML files, 0 forms, 0 findings
- verified the public Action repository and `v1` tag return HTTP 200
- checked the diff for credential-like values

I am the maintainer of the listed Action and used AI-assisted development; I reviewed and tested this contribution.