### PR TITLE
Add ai-i18n action

### DIFF
--- a/.github/workflows/ai-i18n.yml
+++ b/.github/workflows/ai-i18n.yml
@@ -1,0 +1,30 @@
+name: ai-i18n
+
+on:
+  workflow_dispatch:
+  # Typical trigger in a real project - translate whenever the source locale changes:
+  # push:
+  #   branches: [main]
+  #   paths: ['locales/en/**']
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    env:
+      # ai-i18n needs an LLM API key. This example repository has none configured,
+      # so the step is skipped (and the workflow passes) unless ANTHROPIC_API_KEY exists.
+      HAS_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Translate i18n files
+        if: env.HAS_API_KEY == 'true'
+        uses: i18n-actions/ai-i18n@v0.9.0
+        with:
+          provider: anthropic
+          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          source-language: en
+          target-languages: de,fr,es
+          files: 'locales/en/**/*.json'
+          format: json-nested
+          dry-run: true # remove to write the translated files and commit them

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Add Reviewers](https://github.com/marketplace/actions/add-reviewers): Github action that adds Reviewers to the Pull Request.
 
+[![ai-i18n](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/ai-i18n.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/ai-i18n.yml)
+
+[ai-i18n](https://github.com/i18n-actions/ai-i18n): Github Action to automatically translate i18n files (XLIFF, JSON) using LLM providers (Anthropic, OpenAI, Ollama, AWS Bedrock), with change detection, glossary support and preservation of reviewed translations.
+
 [![App Token](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/app-token.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/app-token.yml)
 
 [App Token](https://github.com/marketplace/actions/github-app-token): Github Action to impersonate a GitHub App when `secrets.GITHUB_TOKEN`'s limitations are too restrictive and a personal access token is not suitable.


### PR DESCRIPTION
Follow-up to #1371 (closed as stale before I added the workflow example — sorry about that!).

Adds **ai-i18n** to the Global Actions section (alphabetical slot, between *Add Reviewers* and *App Token*), together with a workflow example under `.github/workflows/ai-i18n.yml`.

[ai-i18n](https://github.com/i18n-actions/ai-i18n) is a GitHub Action that automatically translates i18n files (XLIFF, JSON) using LLM providers (Anthropic, OpenAI, Ollama, AWS Bedrock), with change detection, glossary support and preservation of reviewed translations.

The example workflow is `workflow_dispatch`-triggered. Since the action needs an LLM API key, the translate step is guarded on `secrets.ANTHROPIC_API_KEY` being set — in this repository it is not, so the step is skipped and the workflow passes when you test it. With a key configured it runs in `dry-run` mode against `locales/en/**/*.json`.

Note: the entry links to the action's repository rather than a Marketplace page, as it isn't published to the Marketplace.