### PR TITLE
Add Automation Integration Preflight example

### DIFF
--- a/.github/workflows/automation-integration-preflight.yml
+++ b/.github/workflows/automation-integration-preflight.yml
@@ -1,0 +1,40 @@
+name: Automation Integration Preflight
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: Public HTTP or HTTPS page to inspect
+        required: true
+        default: https://example.com
+        type: string
+      mode:
+        description: Report mode
+        required: true
+        default: analyze
+        type: choice
+        options:
+          - analyze
+          - acceptance-pack
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check automation readiness
+        uses: tinyopsstudio/automation-integration-preflight-action@v1
+        with:
+          url: ${{ inputs.url }}
+          rapidapi-key: ${{ secrets.AUTOMATION_PREFLIGHT_RAPIDAPI_KEY }}
+          mode: ${{ inputs.mode }}
+          objective: Identify integration evidence and practical launch gates.
+          output-file: reports/automation-preflight.json
+      - name: Upload JSON report
+        uses: actions/upload-artifact@v4
+        with:
+          name: automation-preflight-report
+          path: reports/automation-preflight.json

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Auto Merge](https://github.com/marketplace/actions/merge-pull-requests): GitHub Action to automatically merge pull requests when they are ready (`automerged` label).
 
+[![Automation Integration Preflight](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/automation-integration-preflight.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/automation-integration-preflight.yml)
+
+[Automation Integration Preflight](https://github.com/tinyopsstudio/automation-integration-preflight-action): GitHub Action to check a public page for bounded automation-readiness evidence and save a structured JSON report.
+
 [![Branch Names](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/branch-names.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/branch-names.yml)
 
 [Branch Names](https://github.com/marketplace/actions/branch-names): Github Action to get branch or tag information without the `/ref/*` prefix.


### PR DESCRIPTION
## What changed

- adds Automation Integration Preflight to the alphabetical Global Actions list
- adds a manual workflow example using the stable `v1` tag
- keeps workflow permissions at `contents: read`
- uploads the structured JSON report as a workflow artifact

## Why

The Action checks a public page for bounded automation and integration-readiness evidence before implementation. It rejects private-network and credential-like targets, limits redirects and response sizes, checks robots policy, and saves evidence without submitting forms or executing page JavaScript.

## Validation

- `npx --yes yaml-lint .github/workflows/automation-integration-preflight.yml`
- `git diff --check`
- live manual workflow run completed successfully, including the preflight request and JSON artifact upload: https://github.com/tinyopsstudio/useful-actions/actions/runs/32802871643
- privacy scan returned zero findings

The live example uses the repository secret `AUTOMATION_PREFLIGHT_RAPIDAPI_KEY`. The linked API has a free plan with 10 requests per month.