### PR TITLE
Add CSV Preflight action example

### DIFF
--- a/.github/workflows/csv-preflight.yml
+++ b/.github/workflows/csv-preflight.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Create example CSV
         run: printf '%s\n' 'sku,title,price' 'A-1,Blue mug,12.00' > "$RUNNER_TEMP/example.csv"
       - name: Check CSV structure
-        uses: softpeanut/csv-preflight@340b31bb16a4c39463be3378270ea6c628aa5461
+        uses: softpeanut/csv-preflight-action@eb04c527a46ce3bc8bfc711fde8e93ca947597ae
         with:
           path: ${{ runner.temp }}/example.csv
           normalized_path: ${{ runner.temp }}/example.normalized.csv
@@ -25,4 +25,3 @@ jobs:
           path: |
             ${{ runner.temp }}/example.normalized.csv
             ${{ runner.temp }}/example.issues.csv
-

--- a/.github/workflows/csv-preflight.yml
+++ b/.github/workflows/csv-preflight.yml
@@ -1,0 +1,28 @@
+name: CSV Preflight
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create example CSV
+        run: printf '%s\n' 'sku,title,price' 'A-1,Blue mug,12.00' > "$RUNNER_TEMP/example.csv"
+      - name: Check CSV structure
+        uses: softpeanut/csv-preflight@340b31bb16a4c39463be3378270ea6c628aa5461
+        with:
+          path: ${{ runner.temp }}/example.csv
+          normalized_path: ${{ runner.temp }}/example.normalized.csv
+          report_path: ${{ runner.temp }}/example.issues.csv
+      - name: Upload normalized CSV and issue report
+        uses: actions/upload-artifact@v4
+        with:
+          name: csv-preflight-example
+          path: |
+            ${{ runner.temp }}/example.normalized.csv
+            ${{ runner.temp }}/example.issues.csv
+

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [![CSV Preflight](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/csv-preflight.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/csv-preflight.yml)
 
-[CSV Preflight](https://github.com/softpeanut/csv-preflight): GitHub Action to check one UTF-8 CSV for structural problems and save normalized output locally on the runner.
+[CSV Preflight](https://github.com/softpeanut/csv-preflight-action): GitHub Action to check one UTF-8 CSV for structural problems and save normalized output locally on the runner.
 
 [![Curl](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/curl.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/curl.yml)
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Create Pull Request](https://github.com/marketplace/actions/create-pull-request): GitHub Action to create a pull request for changes to your repository in the actions workspace.
 
+[![CSV Preflight](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/csv-preflight.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/csv-preflight.yml)
+
+[CSV Preflight](https://github.com/softpeanut/csv-preflight): GitHub Action to check one UTF-8 CSV for structural problems and save normalized output locally on the runner.
+
 [![Curl](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/curl.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/curl.yml)
 
 [Curl](https://github.com/marketplace/actions/github-action-for-curl): GitHub Action to use the curl CLI to perform http requests.


### PR DESCRIPTION
Adds CSV Preflight to the Global Actions list with a runnable `workflow_dispatch` example.

The example creates a small UTF-8 CSV, runs the Action at an immutable commit, and uploads the normalized CSV and issue report. It grants only `contents: read` and requires no API key.

Disclosure: I maintain the submitted Action.