### PR TITLE
Add RepoDoctor CI action example

### DIFF
--- a/.github/workflows/repodoctor-ci.yml
+++ b/.github/workflows/repodoctor-ci.yml
@@ -1,0 +1,21 @@
+name: RepoDoctor CI
+
+on: [workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  repository-health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Scan repository health
+        uses: BLCCoreStudio/RepoDoctor@60eec782d18c5a5efd696f20e730aee7ce08165e # v0.1.3
+        with:
+          path: .
+          format: terminal
+          language: en

--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [![Replace Values Action](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/replace-values-action.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/replace-values-action.yml): Github Action to replace values in files (secrets or fields).
 
+[![RepoDoctor CI](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repodoctor-ci.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repodoctor-ci.yml)
+
+[RepoDoctor CI](https://github.com/marketplace/actions/repodoctor-ci): GitHub Action to score repository health and enforce configurable CI quality gates across security, testing, dependencies, documentation, configuration, and architecture.
+
 [![Repository-Dispatch](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repository-dispatch.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repository-dispatch.yml) [![Repository-Dispatch-Triggered](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repository-dispatch-triggered.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repository-dispatch-triggered.yml)
 
 [Repository-Dispatch](https://github.com/marketplace/actions/repository-dispatch): GitHub Action to create a repository dispatch event.


### PR DESCRIPTION
## Summary

- add RepoDoctor CI to Global Actions in alphabetical order
- add a workflow_dispatch example with read-only permissions
- pin RepoDoctor CI v0.1.3 to its immutable commit SHA
- require no RepoDoctor account or API key

RepoDoctor CI scores repository health across security, testing, dependencies, documentation, configuration, CI/CD, and architecture, with configurable CI quality gates.

Action: https://github.com/marketplace/actions/repodoctor-ci
Repository: https://github.com/BLCCoreStudio/RepoDoctor

Disclosure: I maintain RepoDoctor CI.