### PR TITLE
Add Scrape Diagnose action

### DIFF
--- a/.github/workflows/scrape-diagnose.yml
+++ b/.github/workflows/scrape-diagnose.yml
@@ -1,0 +1,17 @@
+name: Scrape Diagnose
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Diagnose this repository's public page
+        uses: sanjayamaharjancodes/scrape-diagnose@abe305a38cee37a0287d5bb9d1097964759b8c72
+        with:
+          target-url: https://github.com/GuillaumeFalourd/useful-actions
+          expect-text: useful-actions
+          live: "false"

--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [Retry Action](https://github.com/marketplace/actions/retry-action): GitHub Action to rerun another GitHub Actions and commands.
 
+[![Scrape Diagnose](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/scrape-diagnose.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/scrape-diagnose.yml)
+
+[Scrape Diagnose](https://github.com/sanjayamaharjancodes/scrape-diagnose): GitHub Action to diagnose blocked, challenged, empty, or incomplete public-page fetches.
+
 [![Set Secrets](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/set-secrets.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/set-secrets.yml)
 
 [Set Secrets](https://github.com/marketplace/actions/set-action-secret): Github Action to Create or edit actions secrets in repository or organizations.


### PR DESCRIPTION
## Summary

- add Scrape Diagnose to Global Actions in alphabetical order
- add the required `workflow_dispatch` example
- pin the Action to its full audited commit SHA
- use no checkout, token, or secret and declare `permissions: {}`

The example diagnoses this repository's own public GitHub page, keeping the check associated with the containing repository. A live direct test returned HTTP 200 and matched `useful-actions` without using a provider or paid request.

Self-submission: I maintain the linked Action.

Commercial disclosure: the project's README contains one clearly labeled ScraperAPI affiliate signup link. The Action and its generated reports do not contain or open commercial links.
