### PR TITLE
Add Repo Agent Kit AGENTS.md check example

### DIFF
--- a/.github/workflows/repo-agent-kit-agents-md-check.yml
+++ b/.github/workflows/repo-agent-kit-agents-md-check.yml
@@ -1,0 +1,44 @@
+name: Repo Agent Kit AGENTS.md Check
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-instructions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create an example AGENTS.md
+        run: |
+          printf '%s\n' \
+            '# Repository instructions' \
+            '' \
+            'This Node project ships a small application for maintainers.' \
+            '' \
+            '## Architecture' \
+            '- `src/`: application code and module boundaries.' \
+            '' \
+            '## Commands' \
+            '- `npm test`: run the test suite.' \
+            '- `npm run build`: build production output.' \
+            '' \
+            '## Validation' \
+            'Verify tests pass before completing a change.' \
+            '' \
+            '## Change boundaries' \
+            'Keep changes scoped and preserve the existing architecture.' \
+            '' \
+            '## Safety' \
+            'Never expose secrets or credentials. Do not delete user changes.' \
+            '' \
+            '## Definition of done' \
+            'Done when behavior is verified, tests pass, and the handoff states what changed and any remaining risk.' \
+            > AGENTS.md
+
+      - name: Check AGENTS.md readiness
+        uses: sunxiayi/agents-md-starter-kit@7a7368cf82bf7069ba2cbdfad6e30543afae670e
+        with:
+          path: AGENTS.md
+          fail_below: '86'

--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ This repository lists some useful generic Actions to use in your Github workflow
 
 [![Replace Values Action](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/replace-values-action.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/replace-values-action.yml): Github Action to replace values in files (secrets or fields).
 
+[![Repo Agent Kit AGENTS.md Check](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repo-agent-kit-agents-md-check.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repo-agent-kit-agents-md-check.yml)
+
+[Repo Agent Kit AGENTS.md Check](https://github.com/sunxiayi/agents-md-starter-kit): GitHub Action to score `AGENTS.md` readiness, add a job summary, and enforce an optional threshold without sending file contents off the runner.
+
 [![RepoDoctor CI](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repodoctor-ci.yml/badge.svg)](https://github.com/GuillaumeFalourd/useful-actions/actions/workflows/repodoctor-ci.yml)
 
 [RepoDoctor CI](https://github.com/marketplace/actions/repodoctor-ci): GitHub Action to score repository health and enforce configurable CI quality gates across security, testing, dependencies, documentation, configuration, and architecture.


### PR DESCRIPTION
## Summary

- add a manually runnable workflow for the Repo Agent Kit AGENTS.md readiness Action
- pin the Action to the full `7a7368c` commit SHA
- use a self-contained 100/100 example with read-only permissions and no secrets
- list the Action alphabetically in Global Actions

## Validation

- `git diff --check`
- workflow YAML parses successfully
- the example scores 100/100 (`Ready to use`) at the configured 86 threshold
- all 9 tests in the Action repository pass
- the repository and pinned `action.yml` URLs return HTTP 200

## Disclosure

I maintain Repo Agent Kit and the linked Action. The Action reads only the selected repository-relative instruction file, makes no network request, and does not send file contents off the runner. This contribution was prepared with Codex assistance and manually validated against this repository's contribution rules.